### PR TITLE
adding explicit encoding to "utf-8", default encoding causing problem in windows

### DIFF
--- a/tests/test_train_bpe.py
+++ b/tests/test_train_bpe.py
@@ -38,7 +38,7 @@ def test_train_bpe():
 
     # Compare the learned merges to the expected output merges
     gpt2_byte_decoder = {v: k for k, v in gpt2_bytes_to_unicode().items()}
-    with open(reference_merges_path) as f:
+    with open(reference_merges_path, encoding="utf-8") as f:
         gpt2_reference_merges = [tuple(line.rstrip().split(" ")) for line in f]
         reference_merges = [
             (
@@ -50,7 +50,7 @@ def test_train_bpe():
     assert merges == reference_merges
 
     # Compare the vocab to the expected output vocab
-    with open(reference_vocab_path) as f:
+    with open(reference_vocab_path, encoding="utf-8") as f:
         gpt2_reference_vocab = json.load(f)
         reference_vocab = {
             gpt2_vocab_index: bytes([gpt2_byte_decoder[token] for token in gpt2_vocab_item])


### PR DESCRIPTION
Just a friendly heads-up for Windows users: you might encounter issues when running pytest. This is for awareness to save time if someone encounters it.




On Windows, the default encoding is often a legacy codepage, like cp1252 (Windows-1252). On Windows machine, Python opens it using cp1252 and reads a specific byte (or sequence of bytes) as the non-breaking space character, '\xa0'. This is causing problem.

```
======================================================== FAILURES =========================================================
_____________________________________________________ test_train_bpe ______________________________________________________

    def test_train_bpe():
        input_path = FIXTURES_PATH / "corpus.en"
        vocab, merges = run_train_bpe(
            input_path=input_path,
            vocab_size=500,
            special_tokens=["<|endoftext|>"],
        )
    
        # Path to the reference tokenizer vocab and merges
        reference_vocab_path = FIXTURES_PATH / "train-bpe-reference-vocab.json"
        reference_merges_path = FIXTURES_PATH / "train-bpe-reference-merges.txt"
    
        # Compare the learned merges to the expected output merges
        gpt2_byte_decoder = {v: k for k, v in gpt2_bytes_to_unicode().items()}
        with open(reference_merges_path) as f:
            gpt2_reference_merges = [tuple(line.rstrip().split(" ")) for line in f]
            reference_merges = [
                (
>                   bytes([gpt2_byte_decoder[token] for token in merge_token_1]),
                    bytes([gpt2_byte_decoder[token] for token in merge_token_2]),
                )
                for merge_token_1, merge_token_2 in gpt2_reference_merges
            ]
E           KeyError: '\xa0'

tests\test_train_bpe.py:45: KeyError
================================================= short test summary info =================================================
FAILED tests/test_train_bpe.py::test_train_bpe - KeyError: '\xa0'
```